### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Tools Documentation
 
-This is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.
+[This](https://github.com/materialknight/tools/blob/main/obscure_tutos.md) is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Tools Documentation
 
-[This](https://github.com/materialknight/tools/blob/main/obscure_tutos.md) is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.
+[This](./obscure_tutos.md) is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Tools Documentation
 
-[This](./obscure_tutos.md) is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.
+This is my personal collection of recipes, tutorials, utility scripts, demonstrative examples, and reusable code.
+
+- [Obscure Tutorials](./obscure_tutos.md)


### PR DESCRIPTION
Look at this [perlesvaux.github.io/tools/](https://perlesvaux.github.io/tools/)
My idea is to link all cheatsheets at the README.
So far, only obscure_tutos has been added.
Additionally, each could have a brief explanation of what they are about.